### PR TITLE
Added functions which handle working directories for emender.

### DIFF
--- a/emend
+++ b/emend
@@ -67,7 +67,6 @@ function getScriptDirectory()
 end
 
 
-
 --
 -- Returns current directory. Note that this directory might be different
 -- that result of getScriptDirectory().
@@ -82,6 +81,41 @@ function getCurrentDirectory()
 end
 
 
+--
+-- Returns current temporary emender directory. This directory can be used
+-- for storing all temporary emender data.
+--
+function getWorkingDirectory()
+	local homePath = os.getenv("HOME")
+	local emenderDirName = ".cache/emender"
+
+	-- Check whether this user has home directory.
+	if path.directory_exists(homePath) then
+		local emenderDir = path.compose(homePath, emenderDirName)
+
+		-- Check whether temporary directory already exist or not.
+		if not path.directory_exists(emenderDir) then
+			path.create_dir(emenderDir)
+		end
+
+		-- Return path to the emender temporary directory.
+		return emenderDir
+	end
+end
+
+
+--
+-- Function that removes Emender working directory.
+--
+function removeEmenderWorkDirectory()
+    -- Get Emender temp directory.
+    local emenderWorkDir = getWorkingDirectory()
+
+    -- Check whether removing went well.
+    if not path.remove_dir(emenderWorkDir) then
+        warn("Directory name is not correct or the user does not have permissions to do that.")
+    end
+end
 
 --
 -- Alter the content of "package.path" to contain the relative path
@@ -328,6 +362,15 @@ function main(arg)
     elseif getopt.isTestListOptionUsed(options) then
         -- show list of tests to run if -l or --list option is specified on the command line
         core.performTestList(verboseOperations, colorOutput, testsToRun)
+    elseif getopt.isCleanAllWorkDirsFlagUsed(options) then
+        -- Only remove the emender working directory.
+        removeEmenderWorkDirectory()
+    elseif getopt.isCleanBookWorkDirsFlagUsed(options) then
+        -- Only remove all directories in emender working directory.
+        core.removeBookWorkDirectories()
+    elseif getopt.isCleanCurrentWorkDirFlagUsed(options) then
+        -- Remove only working directory for current book.
+        removeCurrentWorkingDir()
     elseif getopt.isGenDocFlagUsed(options) then
         -- user need to specify name of output file where the generated documentation
         -- will be stored (the -o option is used for two distinct operations)
@@ -350,4 +393,3 @@ function main(arg)
 end
 
 main(arg)
-

--- a/selfchecks/test_module_string.in
+++ b/selfchecks/test_module_string.in
@@ -300,6 +300,12 @@
 
     [ PASS ]  Test if endsWith() function works correctly
 
+  Test Case: testGetHash
+
+    [ PASS ]  Test if getHash() function returns correct hash.
+    [ PASS ]  Test if getHash() function returns correct hash.
+    [ PASS ]  Test if getHash() function returns correct hash.
+
   Test Case: testLastIndexOf1
 
     [ PASS ]  Test if lastIndexOf() function works correctly
@@ -787,8 +793,8 @@
 
   Test Summary                                                            
 
-    Executed Test Cases: 165
-    Passed Test Cases:   165
+    Executed Test Cases: 166
+    Passed Test Cases:   166
     Failed Test Cases:   0
     Encountered Errors:  0
     Overall Result:      PASS

--- a/src/common/getopt.lua
+++ b/src/common/getopt.lua
@@ -1,5 +1,5 @@
 -- getopt.lua - module for handling command line options and flags.
--- 
+--
 -- This file is part of Emender.
 --
 -- Emender is free software: you can redistribute it and/or modify
@@ -158,6 +158,28 @@ function getopt.isGenDocFlagUsed(options)
 end
 
 
+--
+-- Check if --clean-current-workdir is used on the CLI.
+--
+function getopt.isCleanCurrentWorkDirFlagUsed(options)
+    return options["clean-current-workdir"]
+end
+
+--
+-- Check if --clean-emender-workdir is used on the CLI.
+--
+function getopt.isCleanAllWorkDirsFlagUsed(options)
+    return options["clean-emender-workdir"]
+end
+
+
+--
+-- Check if --clean-book-workdirs is used on the CLI.
+--
+function getopt.isCleanBookWorkDirsFlagUsed(options)
+    return options["clean-book-workdirs"]
+end
+
 
 --
 -- Returns table that would contain all unknown command line options.
@@ -166,7 +188,9 @@ function getopt.getUnknownOptions(options)
     local knownOptions = {"v", "verbose",   "l", "list",      "h", "help",
                           "V", "version",   "L", "license",   "c", "color",
                           "s", "summary",   "T", "trace",     "o", "output",
-                          "D", "debug",     "t", "tags",      "G", "gendoc"}
+                          "D", "debug",     "t", "tags",      "G", "gendoc",
+                          "clean-emender-workdir", "clean-book-workdirs",
+                          "clean-current-workdir"}
 
     -- we are going to modify table two times, so let's made a copy of it
     local unknownOptions = table.copy(options)
@@ -333,4 +357,3 @@ function getopt.checkForUnknownOptions(options)
 end
 
 return getopt
-

--- a/src/common/path.lua
+++ b/src/common/path.lua
@@ -119,6 +119,67 @@ function path.file_exists(filename)
     return true
 end
 
+
+--
+--- Function that creates 'dirpath' directory.
+--
+--  @param dirpath - path to the directory (and its parents) which should be created
+--  @return true if directory is created, otherwise nil.
+function path.create_dir(dirpath)
+    -- If dirpath argument is nil or empty string or not string then return nil.
+    if not dirpath or dirpath:match("^$") or type(dirpath) ~= "string" then
+        return nil
+    end
+
+    -- If dir already exists then print information line and return true, because directory is there.
+    if path.directory_exists(dirpath) then
+        warn("Directory '" .. dirpath .. "' already exists.")
+        return true
+    end
+
+    -- Create directories according to dirpath - no error if already exists
+    local command = "mkdir -p " .. dirpath .. " 2>&1"
+    local output = execCaptureOutputAsString(command)
+
+    -- Check whether we have permission for creating dir
+    if output:match("Permission denied") then
+        warn("Emender does not have permissions for creating directory '" .. dirpath .. "'.")
+        return nil
+    end
+
+    return true
+end
+
+
+--
+--- Function that "removes" given directory. In fact, the directory is not removed but only moved to the tempdir.
+-- 	It's made this way because of safety.
+--
+--  @param dirpath path to the directory, which should be (re)moved
+--  @return true if everything is correct, otherwise nil
+function path.remove_dir(dirpath)
+	-- If the argument is nil or empty string or not string type then return nil.
+	if not dirpath or dirpath:match("^$") or type(dirpath) ~= "string" then
+		return nil
+	end
+
+	-- If directory does not exist, print the warning and return nil.
+	if not path.directory_exists(dirpath) then
+		print("Directory '" .. dirpath .. "' does not exist.")
+		return true
+	end
+
+	-- Create temporary directory.
+	local create_mktemp = "mktemp -d"
+    local tmpdir_name = execCaptureOutputAsString(create_mktemp)
+
+	-- Move directory which should be moved.
+	local move_dir = "mv -v " .. dirpath ..  " " .. tmpdir_name
+	execCaptureOutputAsString(move_dir)
+
+	return true
+end
+
+
 -- Export the module:
 return path
-

--- a/src/common/string.lua
+++ b/src/common/string.lua
@@ -131,7 +131,7 @@ end
 --
 function string.trimString(str)
     local pattern = "[%p%s]*(%w.*)$"
-    
+
     -- make sure we don't get 'NPE'
     if not str then
         return nil
@@ -139,12 +139,12 @@ function string.trimString(str)
     if string.len(str) > 3 then
         local getOutput = str:gmatch(pattern)
         local output = getOutput()
-        if not output then 
+        if not output then
           return ""
         end
-        
+
         output = output:reverse()
-        
+
         -- Use the same pattern for the end of reversed string.
         getOutput = output:gmatch(pattern)
         output = getOutput()
@@ -320,3 +320,23 @@ function string:lastIndexOf(str)
         return i-1 end
 end
 
+
+
+--
+--- Function that create sha256 hash from given string.
+--
+--  @param str string from which the hash will be counted.
+--  @return sha256 hash
+function string.getHash(str)
+	-- If the function got nil or something else than string then return nil
+	if not str or type(str) ~= "string" then
+		return nil
+	end
+
+	-- Execute command and get sha256 hash.
+	local command = "echo -n " .. str .. " | sha256sum"
+	local sha256 = execCaptureOutputAsString(command)
+
+	-- Return the hash.
+	return string.trimString(sha256)
+end

--- a/test/TestModuleString.lua
+++ b/test/TestModuleString.lua
@@ -1770,6 +1770,18 @@ function TestModuleString.testAlignCenter6()
 end
 
 
+--
+-- Test the behaviour of the following Emender function: string.getHash().
+--
+function TestModuleString.testGetHash()
+	is_equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", string.getHash(""), "Test if getHash() function returns correct hash.")
+	is_equal("4acf0b39d9c4766709a3689f553ac01ab550545ffa4544dfc0b2cea82fba02a3", string.getHash("testString"), "Test if getHash() function returns correct hash.")
+	is_equal("cee06415bd13a5c222a581bea8c083360c9fa9a5b2ab54a3541c63c40c8ad117", string.getHash("/home/user/books/testing"), "Test if getHash() function returns correct hash.")
+end
+
+
+
+
 
 -- TODO:
 -- string.alignCenter(str, width, indent, first_indent)


### PR DESCRIPTION
Add these new features:
- Emender can create its own working directory in /home/user/.cache/emender . It useful for Emender data which are  used in tests and books.
- By running emend in a directory emender creates working directory. This directory name depends on where the script was run. So If you run the emend command again you will get the same working directory. So, this working directory is useful for saving book-related data (i.e.  for caching).

Three new parameters:
--clean-current-workdir  : removes working directory for current directory.
--clean-books-workdirs : removes all working directories in emender working directory.
--clean-emender-workdir : removes whole emender working directory.