### PR TITLE
Issue #22: Change 1 echo to printf in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install: $(MANS)
 	@echo "Installing manual pages:"
 	$(call install_mans,$(MANS),$(mandir),644)
 	@echo "Installing the executable file:"
-	echo -e "#!/bin/bash\nlua $(datadir)/emend \"\$$@\"" > $(bindir)/emend && chmod 755 $(bindir)/emend
+	printf "#!/bin/bash\nlua $(datadir)/emend \"\$$@\"" > $(bindir)/emend && chmod 755 $(bindir)/emend
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
Addressing: https://github.com/emender/emender/issues/22
Replaced 'echo -e' on line 64 with 'printf' to resolve 'make install' issue where the -e may be echoed rather that treated as an option.